### PR TITLE
Do not rely on ENV var on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ node_js:
   - "8"
 before_script:
   - npm install --prefix server && npm install --prefix client
+services:
+  - mongodb

--- a/server/test/database.js
+++ b/server/test/database.js
@@ -12,7 +12,7 @@ require('dotenv').config({ path: 'variables.env' })
 
 before(done => {
   // Connect to the Database
-  mongoose.connect(process.env.TEST_DATABASE, {
+  mongoose.connect(process.env.TEST_DATABASE || 'mongodb://localhost:27017/fcc-classroom', {
     useMongoClient: true,
   })
 


### PR DESCRIPTION
https://github.com/freeCodeCamp/classroom-mode/pull/90 surfaced a problem where contributor cannot fetch environment variable because of CI restriction, this pull request is intended to fix this problem.

This test should pass without any ENV var set on CI.